### PR TITLE
wait for notebook loaded event

### DIFF
--- a/jupyter_notebookparams/static/main.js
+++ b/jupyter_notebookparams/static/main.js
@@ -40,7 +40,9 @@ define([
     };
     // Run on start
     function load_ipython_extension() {
-      set_parameters();
+      events.on('notebook_loaded.Notebook', function(event, data) {
+        set_parameters();
+      });
     }
     return {
         load_ipython_extension: load_ipython_extension


### PR DESCRIPTION
First of all, thanks for this extension. It's exactly what I need right now.

Most of the times, the notebook was not completely loaded, which resulted in a failure to read the GET parameters. This PR adds an event handler for "notebook loaded".